### PR TITLE
Update 04-manage-application-state-in-gatsby-with-react-hooks.md

### DIFF
--- a/build-a-video-chat-app-with-twilio-and-gatsby/notes/04-manage-application-state-in-gatsby-with-react-hooks.md
+++ b/build-a-video-chat-app-with-twilio-and-gatsby/notes/04-manage-application-state-in-gatsby-with-react-hooks.md
@@ -146,7 +146,7 @@ const Join = () => {
     <>
       <h1>Start or Join a Video Chat</h1>
       <pre>{JSON.stringify(state, null, 2)}</pre>
-      <form className="state-form" onSubmit={handleSubmit}>
+      <form className="start-form" onSubmit={handleSubmit}>
         <label htmlFor="identity">
           Display name:
           <input


### PR DESCRIPTION
Rename className of `<form className="state-form">` to "start-form" due to the class-definitions in layout.css