### PR TITLE
improve code formmating

### DIFF
--- a/composing-closures-and-callbacks-in-javascript/notes/01-intro-to-callbacks-broadcasters-and-listeners/07-solve-callback-hell-with-composition.md
+++ b/composing-closures-and-callbacks-in-javascript/notes/01-intro-to-callbacks-broadcasters-and-listeners/07-solve-callback-hell-with-composition.md
@@ -61,7 +61,11 @@ Is important to notice the pattern here, this code is hard to read and have mult
 We can use `pipe` from `lodash/fp` package and refactor our code
 
 ```javascript
-let timeoutURL = pipe(nest(timeout), nest(getURL))
+let timeoutURL = pipe(
+  nest(timeout),
+  nest(getURL)
+)
+
 timeoutURL(click)((data) => {
   console.log(data)
 })


### PR DESCRIPTION
typically composing functions like pipe put only 1 function call per line.  Helps visually, with PRs, etc.

Extra spacing for 2 separate functions.