### PR TITLE
finished notes for manage-react-state-with-recoil

### DIFF
--- a/manage-react-state-with-recoil/notes/01-Update Recoil State in React using useRecoilState.md
+++ b/manage-react-state-with-recoil/notes/01-Update Recoil State in React using useRecoilState.md
@@ -1,0 +1,11 @@
+<TimeStamp start="0:10" end="0:25">
+
+Atoms contain the source of truth for our application state. In our todo-list, the source of truth will be an array of objects, with each object representing a todo item.
+
+</TimeStamp>
+
+<TimeStamp start="0:40" end="1:05">
+
+useRecoilState is VERY similar to React's useState hook. useRecoilState returns a tuple where the first element is the value of state and the second element is a setter function that will update the value of the given state when called. This hook will implicitly subscribe the component to the given state. [More Info](https://recoiljs.org/docs/api-reference/core/useRecoilState/)
+
+</TimeStamp>

--- a/manage-react-state-with-recoil/notes/02-react-display-computed-data-using-recoil-selectors-in-react.md
+++ b/manage-react-state-with-recoil/notes/02-react-display-computed-data-using-recoil-selectors-in-react.md
@@ -1,0 +1,29 @@
+<TimeStamp start="0:07" end="0:17">
+
+Components that use recoil state need RecoilRoot to appear somewhere in the parent tree. A good place to put this is in your root component.
+
+</TimeStamp>
+
+<TimeStamp start="0:25" end="0:40">
+
+Atoms contain the source of truth for our application state. In our todo-list, the source of truth will be an array of objects, with each object representing a todo item.
+
+</TimeStamp>
+
+<TimeStamp start="0:55" end="1:05">
+
+useRecoilValue simply returns the value of the given Recoil state. It is a read only hook, it cannot write to the state.
+
+</TimeStamp>
+
+<TimeStamp start="2:02" end="2:17">
+
+A selector represents a piece of derived state. You can think of derived state as the output of passing state to a pure function that modifies the given state in some way.
+
+</TimeStamp>
+
+<TimeStamp start="2:35" end="2:55">
+
+The setup for a Selector is very similar to an Atom. They both use a `key` but the second property of this Selector will be a `get`. This particular one will return an object that we will use to calculate our total price.
+
+</TimeStamp>

--- a/manage-react-state-with-recoil/notes/03-react-use-selectorfamily-to-take-arguments-in-your-recoil-selectors.md
+++ b/manage-react-state-with-recoil/notes/03-react-use-selectorfamily-to-take-arguments-in-your-recoil-selectors.md
@@ -1,0 +1,17 @@
+<TimeStamp start="0:18" end="0:33">
+
+A selector represents a piece of derived state. You can think of derived state as the output of passing state to a pure function that modifies the given state in some way.
+
+</TimeStamp>
+
+<TimeStamp start="2:44" end="2:56">
+
+More information on the [luxon library toISODate()](https://moment.github.io/luxon/#/formatting?id=technical-formats-strings-for-computers)
+
+</TimeStamp>
+
+<TimeStamp start="2:44" end="3:04">
+
+[A selectorFamily](https://recoiljs.org/docs/api-reference/utils/selectorFamily/) is a powerful pattern that is similar to a selector, but allows you to pass parameters to the `get` and `set` callbacks of a selector. The `selectorFamily()` utility returns a function which can be called with user-defined parameters and returns a selector. Each unique parameter value will return the same memoized selector instance.
+
+</TimeStamp>

--- a/manage-react-state-with-recoil/notes/04-react-use-recoil-selectors-to-make-api-calls-in-react.md
+++ b/manage-react-state-with-recoil/notes/04-react-use-recoil-selectors-to-make-api-calls-in-react.md
@@ -1,0 +1,18 @@
+<TimeStamp start="1:05" end="1:35">
+
+Trying to consume the `weatherSelector` directly will give us some problems, until the API call returns, all we have is a promise, so React won't know what to render. One way of fixing this is using [React Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html), an experimental feature.
+
+</Timestamp>
+
+<TimeStamp start="2:00" end="2:15">
+
+Suspense can't be at the same level of hierarchy as the value that we're waiting for. We **could** wrap our application in a suspense component, but we would lose the input box and just show "Loading weather..." for the whole application. 
+
+</TimeStamp>
+
+<TimeStamp start="2:25" end="2:35">
+
+To get around the loading issue, we can lower the hierarchy of `<div>Weather: {cityWeather}</div>` by extracting it into it's own component. 
+
+</TimeStamp>
+

--- a/manage-react-state-with-recoil/notes/05-react-handle-recoil-asynchronous-selectors-using-loadables-in-react.md
+++ b/manage-react-state-with-recoil/notes/05-react-handle-recoil-asynchronous-selectors-using-loadables-in-react.md
@@ -1,0 +1,5 @@
+<TimeStamp start="0:46" end="1:00">
+
+Unlike `useRecoilValue()`, [useRecoilValueLoadable()](https://recoiljs.org/docs/api-reference/core/useRecoilValueLoadable/) will not throw an Error or Promise when reading from an asynchronous selector (for the purpose of working alongside React Suspense). Instead, this hook returns a Loadable object.
+
+</TimeStamp>

--- a/manage-react-state-with-recoil/notes/06-react-choose-the-right-hook-for-your-recoil-state.md
+++ b/manage-react-state-with-recoil/notes/06-react-choose-the-right-hook-for-your-recoil-state.md
@@ -1,0 +1,18 @@
+<TimeStamp start="0:26" end="0:40">
+
+[useRecoilValue](https://recoiljs.org/docs/api-reference/core/useRecoilValue/) simply returns the value of the given Recoil state. It is a read only hook, it cannot write to the state. This is best used when you don't want to change the state, but just read/print out what that state is. 
+
+</TimeStamp>
+
+<TimeStamp start="1:22" end="1:42">
+
+[useRecoilState](https://recoiljs.org/docs/api-reference/core/useRecoilState/) returns a tuple where the first element is the value of state and the second element is a setter function that will update the value of the given state when called. This hook will implicitly subscribe the component to the given state. This you will want to use when you want to read and write the state.
+
+</TimeStamp>
+
+<TimeStamp start="1:22" end="1:42">
+
+[useSetRecoilState](https://recoiljs.org/docs/api-reference/core/useSetRecoilState/) is used when you want to update the state but not have it re-render every time the state is changed. It is the primary candidate when you just need to write state. useSetRecoilState returns a setter function for updating the value of writeable Recoil state.
+
+
+</TimeStamp>


### PR DESCRIPTION
![](https://media2.giphy.com/media/l4pTqyJ8XMhLZ3ScE/giphy.gif?cid=5a38a5a28l1e9r218mkryqsessc6277008kyhtk79rmumgen&rid=giphy.gif&ct=g)

I took a bit of a different approach to notes here. I didn't want to just have code in the notes blocks, I wanted to add more info for the users. When the instructor uses a new piece of the recoil library, I either wrote out a definition with the link to the recoil docs specific to that code or took the definition from the docs and still linked to it. 

I feel like this might be a better way to go since users can copy code from the code that the instructor provides. I would love some feedback on this way of doing the notes. 