### PR TITLE
Trimmed Timestamp Notes for Up and Running with redux-observable 

### DIFF
--- a/up-and-running-with-redux-observable/notes/01-react-add-redux-to-a-react-application.md
+++ b/up-and-running-with-redux-observable/notes/01-react-add-redux-to-a-react-application.md
@@ -1,6 +1,6 @@
 ## 01. Add Redux to a React application
 
-<Timestamp start="0:00" end="0:30">
+<Timestamp start="0:00" end="0:20">
     
 No longer need to globally install create-react-app. Just use `npx create-react-app redux-obs` here.
 

--- a/up-and-running-with-redux-observable/notes/03-redux-observable-add-redux-observable-to-an-existing-redux-project.md
+++ b/up-and-running-with-redux-observable/notes/03-redux-observable-add-redux-observable-to-an-existing-redux-project.md
@@ -5,27 +5,38 @@
 As of redux-observable 1.0.0, we no longer provide rootEpic to createEpicMiddleware. Instead, we call `epicMiddleware.run(rootEpic)` after creating our store with it. Our middleware setup should look as follows:
 
 ```
-import { applyMiddleware, createStore } from "redux"
-import { createEpicMiddleware } from "redux-observable"
-import { rootEpic } from "./epics"
-
 const epicMiddleware = createEpicMiddleware();
 const store = createStore(reducer, applyMiddleware(epicMiddleware));
 epicMiddleware.run(rootEpic);
 ```
 
-See https://redux-observable.js.org/MIGRATION.html for more information.
+</Timestamp>
+
+<Timestamp start="2:50" end="3:40">
+
+RxJS Operators are now piped to Observables using the `Observable.pipe(operator1, operator2, ...)` syntax. This means that we need to import each RxJS operator separately from `rxjs/operators`.
+
+```
+import { tap, ignoreElements } from "rxjs/operators"
+
+function loadStoriesEpic(action$) {
+    return action$.pipe(
+        tap((action) => console.log(action)),
+        ignoreElements()
+    )
+}
+```
+
+Note also that the RxJS `do` operator has been replaced with `tap`.
 
 </Timestamp>
 
-<Timestamp start="1:40" end="4:50">
+<Timestamp start="4:15" end="4:50">
 
-RxJS Operators are now piped to Observables using the `Observable.pipe(operator1, operator2, ...)` syntax. This means that we need to import each RxJS operator separately from `rxjs/operators`. Also, with pipeable operators, `do()` is replaced with `tap()` (see https://www.learnrxjs.io/learn-rxjs/operators/utility/do). Thus, to match the functionality demonstrated in the lesson our `epics/index.js` should look like
+With pipeable operators, we now can filter the action type as follows (some imports omitted):
 
 ```
 import { tap, ignoreElements, filter } from "rxjs/operators"
-import { combineEpics } from "redux-observable"
-import { LOAD_STORIES } from "../actions"
 
 function loadStoriesEpic(action$) {
     return action$.pipe(
@@ -34,22 +45,16 @@ function loadStoriesEpic(action$) {
         ignoreElements()
     )
 }
-
-export const rootEpic = combineEpics(loadStoriesEpic);
 ```
-
-See https://rxjs.dev/guide/operators for more information.
 
 </Timestamp>
 
 <Timestamp start="4:51" end="5:20">
 
-Instead of calling `ofType()` on the `action$` observable as is done in the lesson, we want to import `ofType` from "redux-observable" and `pipe` it into `action$`:
+We'll want to import the `ofType` operator from "redux-observable" and pipe it into `action$` as follows (some unchanged code/imports omitted):
 
 ```
-import { tap, ignoreElements} from "rxjs/operators"
 import { combineEpics, ofType } from "redux-observable"
-import { LOAD_STORIES } from "../actions"
 
 function loadStoriesEpic(action$) {
     return action$.pipe(
@@ -58,21 +63,19 @@ function loadStoriesEpic(action$) {
         ignoreElements()
     )
 }
-
-export const rootEpic = combineEpics(loadStoriesEpic);
 ```
 
 </Timestamp>
 
-<Timestamp start="5:30" end="6:49">
+<Timestamp start="5:30" end="6:20">
     
-With the previously noted changes to RxJS operators, we now must use the `pipe()` syntax to pipe the `ofType()` and `switchMap()` operators to `action$`. Furthermore, `of()` is now a standalone function that returns an Observable, and we must again use `pipe()` to pipe `delay` to that Observable. Our `epics/index.js` should now look like
+We should now use the `pipe()` syntax to pipe the `ofType()` and `switchMap()` operators to `action$`. Furthermore, `of()` is now a standalone function that returns an Observable, and we must again pipe the `delay` operator into that Observable. We can see these changes made in the code that follows (some unchanged code/imports omitted):
 
 ```
 import { of } from "rxjs";
 import { delay, switchMap } from "rxjs/operators";
 import { combineEpics, ofType } from "redux-observable";
-import { clear, LOAD_STORIES } from "../actions";
+
 function loadStoriesEpic(action$) {
   return action$.pipe(
     ofType(LOAD_STORIES),
@@ -81,10 +84,7 @@ function loadStoriesEpic(action$) {
     })
   );
 }
-export const rootEpic = combineEpics(loadStoriesEpic);
 ```
-
-See https://rxjs.dev/guide/operators for more information.
 
 </Timestamp>
 
@@ -97,3 +97,7 @@ An Epic is a function that takes in a stream of actions and returns a stream of 
 `combineEpics()` from redux-observable allows us to register multiple functions
 
 Everytime the LOAD_STORIES action has been processed by the Redux store, we will receive that action in our Epic stream.
+
+See https://rxjs.dev/guide/operators and https://www.learnrxjs.io/learn-rxjs/operators/utility/do for more information about discussed updates and deprecations in RxJS.
+
+See https://redux-observable.js.org/MIGRATION.html for more information about discussed updates and deprecations in redux-observable.

--- a/up-and-running-with-redux-observable/notes/05-redux-use-redux-observable-for-simple-ajax-requests.md
+++ b/up-and-running-with-redux-observable/notes/05-redux-use-redux-observable-for-simple-ajax-requests.md
@@ -1,8 +1,9 @@
 ## Use redux-observable for simple Ajax requests
 
-<Timestamp start="0:00" end="0:30">
+<Timestamp start="0:10" end="0:25">
     
-The contents of `epics/index.js` at the start of the lesson are as follows:
+The contents of `epics/index.js` at this point in the lesson are as follows:
+
 ```
 import { combineEpics } from "redux-observable";
 import { FETCH_USER, fetchUserFulfilledAction } from "../actions/index";
@@ -11,15 +12,28 @@ export const rootEpic = combineEpics();
 
 </Timestamp>
 
-<Timestamp start="4:35" end="6:13">
+<Timestamp start="4:45" end="5:00">
     
-As mentioned in prior lessons, updates to RxJS operators require us to change the code of our Epic to match the functionality in the lesson. The new implementation for `fetchUserEpic` is as follows:
+Updates to RxJS require us `pipe` operators like `ofType` and `switchMap` into `action$`.
+
+</Timestamp>
+
+<Timestamp start="5:01" end="5:20">
+
+`ajax` is now a standalone Observable creation operator. We can now use `ajax.getJSON` to make our GET request to the API.
+
+</Timestamp>
+
+<Timestamp start="5:30" end="6:00">
+
+We can implement `fetchUserEpic` as follows (some unchanged code/imports omitted):
 
 ```
 import { combineEpics, ofType } from "redux-observable";
 import { map, switchMap } from "rxjs";
-import { FETCH_USER, fetchUserFulfilledAction } from "../actions/index";
 import { ajax } from "rxjs/ajax";
+...
+
 function fetchUserEpic(action$) {
   return action$.pipe(
     ofType(FETCH_USER),
@@ -32,13 +46,12 @@ function fetchUserEpic(action$) {
     })
   );
 }
-export const rootEpic = combineEpics(fetchUserEpic);
 ```
-
-See https://rxjs.dev/guide/operators and https://www.learnrxjs.io/learn-rxjs/operators/creation/ajax for more information.
 
 </Timestamp>
 
-Actions and, more specifically, action names are the glue between Redux and redux-observable, so it's helpful to define actions first.
+Actions (more specifically, action names) are the glue between Redux and redux-observable. In this way, it's helpful to define actions first.
 
 We can fetch data from an API in redux-observable using the RxJS `ajax.getJSON()` Observable creation operator.
+
+See https://rxjs.dev/guide/operators and https://www.learnrxjs.io/learn-rxjs/operators/creation/ajax for more information on relevant updates to RxJS.

--- a/up-and-running-with-redux-observable/notes/07-redux-debounce-user-input-to-avoid-repeated-ajax-requests.md
+++ b/up-and-running-with-redux-observable/notes/07-redux-debounce-user-input-to-avoid-repeated-ajax-requests.md
@@ -12,17 +12,15 @@ Now, when the instructor refers to the `ajax` variable, we should use the `ajaxG
 
 <Timestamp start="4:15" end="4:50">
     
-With newer versions of RxJS, we must use the `pipe()` syntax to pipe operators into our Observables. The following code is the correct implementation of the lesson code in newer versions of RxJS:
+With newer versions of RxJS, we'll want to `pipe` these operators into the Observables. Here is a working implementation of that (some unchanged code/imports omitted.
 
 ```
 import { combineEpics, ofType } from "redux-observable";
 import { map, switchMap } from "rxjs";
 import { ajax } from "rxjs/ajax";
-import { receiveBeers, SEARCHED_BEERS } from "../actions";
-
-const beers = `https://api.punkapi.com/v2/beers`;
-const search = (term) => `${beers}?beer_name=${encodeURIComponent(term)}`;
+...
 const ajaxGet = (term) => ajax.getJSON(search(term));
+...
 
 function searchBeersEpic(action$) {
   return action$.pipe(
@@ -32,38 +30,24 @@ function searchBeersEpic(action$) {
     })
   );
 }
-export const rootEpic = combineEpics(searchBeersEpic);
 ```
-
-See https://rxjs.dev/guide/operators
 
 </Timestamp>
 
-<Timestamp start="6:00" end="7:35">
+<Timestamp start="6:30" end="7:35">
     
-Again, we need to change the lesson code to use the `pipe()` syntax in newer versions of RxJS:
+Again, in newer versions of RxJS, we need to `pipe` operators like `debounceTime` into `action$` as follows (some unchanged code/imports omitted):
 
 ```
-import { combineEpics, ofType } from "redux-observable";
 import { debounceTime, map, switchMap } from "rxjs";
-import { ajax } from "rxjs/ajax";
-import { receiveBeers, SEARCHED_BEERS } from "../actions";
-
-const beers = `https://api.punkapi.com/v2/beers`;
-const search = (term) => `${beers}?beer_name=${encodeURIComponent(term)}`;
-const ajaxGet = (term) => ajax.getJSON(search(term));
-
-function searchBeersEpic(action$) {
-  return action$.pipe(
+...
+return action$.pipe(
     ofType(SEARCHED_BEERS),
     debounceTime(500),
     switchMap(({ payload }) => {
       return ajaxGet(payload).pipe(map(receiveBeers));
     })
   );
-}
-
-export const rootEpic = combineEpics(searchBeersEpic);
 ```
 
 </Timestamp>
@@ -73,3 +57,5 @@ The RxJS `switchMap` operator unsubscribes from the old AJAX request and resubsc
 The `debounceTime()` operator subscribes to the stream before it, and has an internal timer (of time specified) that keeps resetting while events are entering the stream. The element is only let through to the next operator when the timer has completed.
 
 `debounceTime(500)` acts as a barrier or a gate that drops events that occur within 500 milliseconds of eachother. So, while the user is typing at a steady pace, no AJAX requests are made. A request is made only when the user stops typing for 500 milliseconds.
+
+See https://rxjs.dev/guide/operators for more information about updates to RxJS operators.

--- a/up-and-running-with-redux-observable/notes/08-redux-handle-network-errors-gracefully.md
+++ b/up-and-running-with-redux-observable/notes/08-redux-handle-network-errors-gracefully.md
@@ -2,17 +2,15 @@
 
 <Timestamp start="0:00" end="0:45">
     
-We wrote the code for this Epic in the last lesson. To work on newer versions of RxJS, we need to use the `pipe()` syntax on Observables. Furthermore, the `ajax` function is now standalone and does not need to be called on an Observable. Working code for this Epic on the newest versions of RxJS are as follows:
+We wrote the code for this Epic in the last lesson. RxJS has been updated such that we now need to `pipe` operators into `action$`. Furthermore, `ajax` is now a standalone Observable creation operator. Relevant changes to the code are outlined below:
 
 ```
 import { combineEpics, ofType } from "redux-observable";
 import { debounceTime, map, switchMap } from "rxjs";
 import { ajax } from "rxjs/ajax";
-import { receiveBeers, SEARCHED_BEERS } from "../actions";
-
-const beers = `https://api.punkapi.com/v2/beers`;
-const search = (term) => `${beers}?beer_name=${encodeURIComponent(term)}`;
+...
 const ajaxGet = (term) => ajax.getJSON(search(term));
+...
 
 function searchBeersEpic(action$) {
   return action$.pipe(
@@ -23,15 +21,11 @@ function searchBeersEpic(action$) {
     })
   );
 }
-
-export const rootEpic = combineEpics(searchBeersEpic);
 ```
-
-See https://rxjs.dev/guide/operators and https://www.learnrxjs.io/learn-rxjs/operators/creation/ajax for more information.
 
 </Timestamp>
 
-<Timestamp start="0:45" end="1:15">
+<Timestamp start="0:46" end="1:15">
     
 RxJS Observables no longer have the `throw` method. Instead, we use the `throwError` Observable creation operator to throw an error. We should now have:
 
@@ -44,27 +38,19 @@ const ajaxGet = (term) =>
     : ajax.getJSON(search(term));
 ```
 
-See https://rxjs.dev/api/index/function/throwError
+</Timestamp>
+
+<Timestamp start="3:30" end="4:00">
+    
+In newer versions of RxJS, the `catch()` operator has changed to the `catchError()` operator. Furthermore, we'll want to `pipe` the `catchError()` operator into the `ajaxGet` observable. Lastly, `of()` is now a standalone Observable creation operator that no longer needs to be called on `Observable`:
 
 </Timestamp>
 
-<Timestamp start="3:30" end="4:15">
-    
-In newer versions of RxJS, the `catch()` operator has changed to the `catchError()` operator. Furthermore, we'll want to `pipe()` the `catchError()` operator into the `ajaxGet` observable. Lastly, `of()` is now a standalone Observable creation operator that no longer needs to be called on `Observable`:
+<Timestamp start="4:00" end="4:15">
+
+Omitting some unchanged imports/code, we can implement `searchBeersEpic` on newer versions of RxJS as follows:
 
 ```
-import { combineEpics, ofType } from "redux-observable";
-import { catchError, debounceTime, map, of, switchMap, throwError } from "rxjs";
-import { ajax } from "rxjs/ajax";
-import { receiveBeers, searchBeersError, SEARCHED_BEERS } from "../actions";
-
-const beers = `https://api.punkapi.com/v2/beers`;
-const search = (term) => `${beers}?beer_name=${encodeURIComponent(term)}`;
-const ajaxGet = (term) =>
-  term === "skull"
-    ? throwError(() => new Error("Ajax failed!"))
-    : ajax.getJSON(search(term));
-
 function searchBeersEpic(action$) {
   return action$.pipe(
     ofType(SEARCHED_BEERS),
@@ -79,12 +65,16 @@ function searchBeersEpic(action$) {
     })
   );
 }
-
-export const rootEpic = combineEpics(searchBeersEpic);
 ```
-
-See https://rxjs.dev/api/operators/catchError and https://rxjs.dev/api/index/function/of.
 
 </Timestamp>
 
 We should expect anything that "talks to the outside world" (API calls, in this case) to potentially throw an error. We'll want to catch those errors by piping `catchError()` into our Observable.
+
+The following resources provide information about updates/deprecations to RxJS that are relevant to this lesson:
+
+-   https://rxjs.dev/guide/operators
+-   https://www.learnrxjs.io/learn-rxjs/operators/creation/ajax
+-   https://rxjs.dev/api/index/function/throwError
+-   https://rxjs.dev/api/operators/catchError
+-   https://rxjs.dev/api/index/function/of

--- a/up-and-running-with-redux-observable/notes/09-redux-filter-a-stream-to-exclude-empty-values.md
+++ b/up-and-running-with-redux-observable/notes/09-redux-filter-a-stream-to-exclude-empty-values.md
@@ -1,28 +1,24 @@
 ## Filter a stream to exclude empty values
 
-<Timestamp start="0:37" end="1:50">
+<Timestamp start="0:37" end="0:47">
 
-On newer versions of RxJS, we need to use the `pipe()` syntax to pipe our operators into the Observable. The following code implements the functionality demonstrated in the lesson but on newer versions of RxJS:
+We've worked on `searchBeersEpic` throughout the past couple of lessons, so you may want to go back and see the necessary updates to the RxJS code before moving on.
+
+</Timestamp>
+
+<Timestamp start="0:48" end="1:10">
+
+To summarize updates to RxJS here, we now `pipe` operators into the Observable instead of calling them as methods on the Observable. Furthermore, `ajax` is now a standalone Observable creation operator, so it no longer needs to be called as a method on `Observable`. See https://rxjs.dev/guide/operators for more information.
+
+</Timestamp>
+
+<Timestamp start="1:11" end="1:31">
+
+We can see how `pipe` works with the addition of the `filter` operator:
 
 ```
-import { combineEpics, ofType } from "redux-observable";
-import {
-  catchError,
-  debounceTime,
-  filter,
-  map,
-  of,
-  switchMap,
-  throwError,
-} from "rxjs";
-import { ajax } from "rxjs/ajax";
-import { receiveBeers, searchBeersError, SEARCHED_BEERS } from "../actions";
-const beers = `https://api.punkapi.com/v2/beers`;
-const search = (term) => `${beers}?beer_name=${encodeURIComponent(term)}`;
-const ajaxGet = (term) =>
-  term === "skull"
-    ? throwError(() => new Error("Ajax failed!"))
-    : ajax.getJSON(search(term));
+import { catchError, debounceTime, filter, map, of, switchMap, throwError } from "rxjs";
+...
 function searchBeersEpic(action$) {
   return action$.pipe(
     ofType(SEARCHED_BEERS),
@@ -38,51 +34,30 @@ function searchBeersEpic(action$) {
     })
   );
 }
-export const rootEpic = combineEpics(searchBeersEpic);
 ```
-
-See https://rxjs.dev/guide/operators
 
 </Timestamp>
 
-<Timestamp start="4:20" end="6:05">
+<Timestamp start="4:40" end="4:52">
 
-With the `pipe()` syntax in newer versions of RxJS, working code will look a bit different here. Furthermore, `of()` is now a standalone Observable creation operator and no longer needs to be called on an Observable. This is also the case with `concat()`, although it is now recommended to replace the `concat()` operator with `concatWith()` and, in this case, pipe `concatWith(request)` into `loading`. The following code demonstrates all of these changes:
+`of()` is now a standalone Observable creation operator and no longer needs to be called on an Observable.
+
+</Timestamp>
+
+<Timestamp start="5:00" end="5:30">
+
+`concat()` is also now a standalone Observable creation opertaor, although it is now recommended to replace the `concat()` operator with `concatWith()` and, in this case, pipe `concatWith(request)` into the `loading` observable. These changes are demonstrated below:
 
 ```
-import { combineEpics, ofType } from "redux-observable";
-import {
-  catchError,
-  concatWith,
-  debounceTime,
-  filter,
-  map,
-  of,
-  switchMap,
-  throwError,
-} from "rxjs";
-import { ajax } from "rxjs/ajax";
-import {
-  receiveBeers,
-  searchBeersError,
-  searchBeersLoading,
-  SEARCHED_BEERS,
-} from "../actions";
-const beers = `https://api.punkapi.com/v2/beers`;
-const search = (term) => `${beers}?beer_name=${encodeURIComponent(term)}`;
-const ajaxGet = (term) =>
-  term === "skull"
-    ? throwError(() => new Error("Ajax failed!"))
-    : ajax.getJSON(search(term));
+import { catchError, concatWith, debounceTime, filter, map, of, switchMap, throwError } from "rxjs";
+...
 function searchBeersEpic(action$) {
   return action$.pipe(
     ofType(SEARCHED_BEERS),
     debounceTime(500),
     filter((action) => action.payload !== ""),
     switchMap(({ payload }) => {
-      // loading state in UI
       const loading = of(searchBeersLoading(true));
-      // external API call
       const request = ajaxGet(payload).pipe(
         map(receiveBeers),
         catchError((err) => {
@@ -92,14 +67,16 @@ function searchBeersEpic(action$) {
       return loading.pipe(concatWith(request));
     })
   );
-}
-export const rootEpic = combineEpics(searchBeersEpic);
 ```
-
-See https://rxjs.dev/api/operators/concatWith and https://rxjs.dev/api/index/function/of for more information
 
 </Timestamp>
 
 The RxJS `filter` operator can help us bail out of an action under some condition.
 
 The RxJS `concat` (now replaced by `concatWith()`) operator creates a higher-order Observable that "strings Observables together": the operator takes in any number of arguments and subscribes to them in sequence, each waiting for the previous to complete successfully.
+
+The following resources provide information about updates/deprecations to RxJS that are relevant to this lesson:
+
+-   https://rxjs.dev/guide/operators
+-   https://rxjs.dev/api/operators/concatWith
+-   https://rxjs.dev/api/index/function/of

--- a/up-and-running-with-redux-observable/notes/10-react-use-an-action-to-cancel-an-ajax-request.md
+++ b/up-and-running-with-redux-observable/notes/10-react-use-an-action-to-cancel-an-ajax-request.md
@@ -5,6 +5,8 @@
 To match the functionality at this point in the lesson, we need to include `delay` as an import from `"rxjs"` and `pipe()` it into our AJAX get request:
 
 ```
+import { catchError, concatWith, debounceTime, delay, filter, map, of, switchMap, takeUntil, throwError } from "rxjs";
+...
 const ajaxGet = (term) =>
   term === "skull"
     ? throwError(() => new Error("Ajax failed!"))
@@ -19,85 +21,52 @@ const request = ajaxGet(payload).pipe(
 );
 ```
 
-See https://rxjs.dev/guide/operators for more information.
-
 </Timestamp>
 
-<Timestamp start="0:50" end="2:50">
+<Timestamp start="0:50" end="1:05">
 
-The instructor moves the `delay` operator up and out of the way, so remember to `pipe()` this operator into the `ajax.getJSON()` observable. We also must pipe `takeUntil()` into our AJAX GET Observable, and pipe `ofType()` into the `action$` stream:
+The instructor moves the `delay` operator up and out of the way, so remember to `pipe()` this operator into the `ajax.getJSON()` observable.
 
 ```
-import { combineEpics, ofType } from "redux-observable";
-import {
-  catchError,
-  concatWith,
-  debounceTime,
-  delay,
-  filter,
-  map,
-  of,
-  switchMap,
-  takeUntil,
-  throwError,
-} from "rxjs";
-import { ajax } from "rxjs/ajax";
-import {
-  receiveBeers,
-  searchBeersError,
-  searchBeersLoading,
-  SEARCHED_BEERS,
-} from "../actions";
-const beers = `https://api.punkapi.com/v2/beers`;
-const search = (term) => `${beers}?beer_name=${encodeURIComponent(term)}`;
+...
 const ajaxGet = (term) =>
   term === "skull"
     ? throwError(() => new Error("Ajax failed!"))
     : ajax.getJSON(search(term)).pipe(delay(5000));
-function searchBeersEpic(action$) {
-  return action$.pipe(
-    ofType(SEARCHED_BEERS),
-    debounceTime(500),
-    filter((action) => action.payload !== ""),
-    switchMap(({ payload }) => {
-      // loading state in UI
-      const loading = of(searchBeersLoading(true));
-      // external API call
-      const request = ajaxGet(payload).pipe(
-        takeUntil(action$.pipe(
-          ofType(CANCEL_SEARCH)
-        )),
-        map(receiveBeers),
-        catchError((err) => {
-          return of(searchBeersError(err));
-        })
-      );
-      return loading.pipe(concatWith(request));
-    })
-  );
-}
-export const rootEpic = combineEpics(searchBeersEpic);
 ```
 
 </Timestamp>
 
-<Timestamp start="3:00" end="3:35">
+<Timestamp start="1:10" end="1:30">
+
+We must import `takeUntil` from `'rxjs'` and pipe it into our `ajax` GET Observable. Then, where the instructor uses `action$.ofType`, we will pipe `ofType()` into the `action$` stream:
+
+```
+const request = ajaxGet(payload).pipe(
+  takeUntil(action$.pipe(
+    ofType(CANCEL_SEARCH)
+  )),
+  map(receiveBeers),
+  catchError((err) => {
+    return of(searchBeersError(err));
+  })
+);
+```
+
+</Timestamp>
+
+<Timestamp start="3:00" end="3:30">
 
 To match the functionality described at this point in the lesson, we should replace `merge` with the `mergeWith` operator and pipe it. Furthermore, we should pipe `ofType()` into each `action$` stream. An example of this is shown below:
 
 ```
 switchMap(({ payload }) => {
-    // loading state in UI
     const loading = of(searchBeersLoading(true));
 
-    // new implementation of merge (mergeWith) and ofType operators
     const cancel$ = action$.pipe(ofType(CANCEL_SEARCH))
     const navigate$ = action$.pipe(ofType(NAVIGATE))
-    const blockers = cancel$.pipe(
-        mergeWith(navigate$)
-    );
+    const blockers = cancel$.pipe(mergeWith(navigate$));
 
-    // external API call
     const request = ajaxGet(payload).pipe(
         takeUntil(blockers),
         map(receiveBeers),
@@ -109,10 +78,14 @@ switchMap(({ payload }) => {
 })
 ```
 
-See https://rxjs.dev/api/operators/mergeWith about `mergeWith()` and https://redux-observable.js.org/docs/basics/Epics.html about `ofType()`
-
 </Timestamp>
 
 The RxJS `takeUntil()` operator will accept elements from the stream before it only until the stream provided as an argument produces a value. Once the stream provided as an argument produces a value, `takeUntil()` will unsubscribe from the previous Observable. This is useful for cancelling an AJAX request.
 
 `takeUntil()` handles the subscription and unsubscription for us so that we can avoid an imperative style of programming. The operator will also handle the subscription to and unsubscription from the stream provided as an argument.
+
+The following resources provide information about updates/deprecations to RxJS that are relevant to this lesson:
+
+-   https://rxjs.dev/guide/operators
+-   https://rxjs.dev/api/operators/mergeWith
+-   https://redux-observable.js.org/docs/basics/Epics.html

--- a/up-and-running-with-redux-observable/notes/11-react-testing-the-output-of-epics.md
+++ b/up-and-running-with-redux-observable/notes/11-react-testing-the-output-of-epics.md
@@ -1,6 +1,6 @@
 ## Testing the output of epics
 
-<Timestamp start="0:00" end="0:55">
+<Timestamp start="0:05" end="0:25">
     
 On newer versions of RxJS, our `fetchUserEpic()` will need to use the `pipe()` syntax. Below is an implementation of the Epic on newer versions of RxJS:
 
@@ -21,21 +21,25 @@ export function fetchUserEpic(action$) {
 }
 ```
 
-See https://rxjs.dev/guide/operators for more information.
+</Timestamp>
+
+<Timestamp start="1:15" end="1:35">
+
+If we want to take this approach with newer versions of RxJS, then we should use `of` as a standalone Observable creation operator. That is, `of` is no longer a method of `Observable`.
 
 </Timestamp>
 
-<Timestamp start="0:56" end="1:30">
+<Timestamp start="1:36" end="1:51">
     
-Now that RxJS has pipeable operators, we do not need to define an `ofType()` method on `action$`! We can simply create an Observable with the `of()` operator and set `action$` to that.
+Now that RxJS has pipeable operators, we do not need an `ActionsObservable`! In fact, `ActionsObservable` has been removed completely. Now, we can simply set `action$` to an Observable created with the `of` operator.
 
 `const action$ = of({ type: "FETCH_USER", payload: "shakyshane" });`
 
 </Timestamp>
 
-<Timestamp start="1:33" end="2:25">
+<Timestamp start="1:52" end="2:22">
 
-Again, now that RxJS has switched to pipeable operators, there is no need to provide an `ofType()` method on the prototype of the `action$` stream. Thus, `ActionsObservable` has been removed in favor of pipeable operators. So, on newer versions of RxJS and redux-observable, our test should look like:
+So, on newer versions of RxJS and redux-observable, our test should look like:
 
 ```
 import { of } from "rxjs";
@@ -53,9 +57,19 @@ See https://redux-observable.js.org/CHANGELOG.html#200-alpha0-2019-11-14 for mor
 
 </Timestamp>
 
-<Timestamp start="2:30" end="3:26">
+<Timestamp start="2:30" end="2:45">
 
-With newer versions of RxJS, we'll want to pipe `toArray()` into `output$`. Also, I found that this test would pass regardless of whether the assertion was true. Passing in a `done` argument for the test and calling it at the end of the assertions fixed this issue (see https://stackoverflow.com/a/51640742). Now, the test passes almost immediately if the assertions hold and times out if the assertions are defied. Our test should look like:
+With newer versions of RxJS, we'll want to pipe `toArray()` into `output$`.
+
+```
+output$.pipe(toArray()).subscribe(...)
+```
+
+</Timestamp>
+
+<Timestamp start="2:46" end="3:26">
+
+I found that this test would pass regardless of whether the assertion was true. Passing in a `done` argument for the test and calling it at the end of the assertions fixed this issue (see https://stackoverflow.com/a/51640742). Now, the test passes almost immediately if the assertions hold and times out otherwise. Our test should look as follows:
 
 ```
 import { of, toArray } from "rxjs";
@@ -75,3 +89,10 @@ it("should return correct actions", (done) => {
 We can unit test Epics just like any other function in our application. Because we are dealing with observables, we need a way of mocking the input stream.
 
 Since the Epic returns an observable, we can subscribe to it and assert on the actions that come out on the other end.
+
+The following resources provide information about updates/deprecations to RxJS that are relevant to this lesson:
+
+-   https://rxjs.dev/guide/operators
+-   https://rxjs.dev/api/index/function/of
+-   https://redux-observable.js.org/CHANGELOG.html#200-alpha0-2019-11-14
+-   https://stackoverflow.com/a/51640742

--- a/up-and-running-with-redux-observable/notes/12-redux-mocking-an-ajax-request-when-testing-epics.md
+++ b/up-and-running-with-redux-observable/notes/12-redux-mocking-an-ajax-request-when-testing-epics.md
@@ -1,80 +1,32 @@
 ## Mocking an ajax request when testing epics
 
-<Timestamp start="0:00" end="0:44">
+<Timestamp start="0:05" end="0:35">
 
-Our `searchBeersEpic()` looks a lot different with the changes made in newer versions of RxJS. Below is an implementation of the functionality demonstrated in the lesson on newer versions of RxJS and redux-observable.
-
-```
-import { combineEpics, ofType } from "redux-observable";
-import {
-  catchError,
-  concatWith,
-  debounceTime,
-  filter,
-  map,
-  of,
-  switchMap,
-  takeUntil,
-} from "rxjs";
-import { ajax } from "rxjs/ajax";
-import {
-  receiveBeers,
-  searchBeersError,
-  searchBeersLoading,
-  SEARCHED_BEERS,
-  CANCEL_SEARCH,
-} from "../actions";
-const beers = `https://api.punkapi.com/v2/beers`;
-const search = (term) => `${beers}?beer_name=${encodeURIComponent(term)}`;
-export function searchBeersEpic(action$) {
-  return action$.pipe(
-    ofType(SEARCHED_BEERS),
-    debounceTime(500),
-    filter((action) => action.payload !== ""),
-    switchMap(({ payload }) => {
-      // loading state in UI
-      const loading = of(searchBeersLoading(true));
-      // external API call
-      const request = ajax.getJSON(search(payload)).pipe(
-        takeUntil(action$.pipe(ofType(CANCEL_SEARCH))),
-        map(receiveBeers),
-        catchError((err) => {
-          return of(searchBeersError(err));
-        })
-      );
-      return loading.pipe(concatWith(request));
-    })
-  );
-}
-export const rootEpic = combineEpics(searchBeersEpic);
-```
+Our `searchBeersEpic()` looks a lot different with the updates made in newer versions of RxJS. Before viewing this lesson, you probably should follow along with lessons 7 through 10 of this course and their corresponding notes. This way, you can understand the implementation of this Epic and the updates that need to be made to the code so that it works on newer versions of RxJS.
 
 </Timestamp>
 
-<Timestamp start="0:45" end="2:00">
+<Timestamp start="0:45" end="1:20">
 
-As mentioned in the last lesson, `ActionsObservable` has been removed from redux-observable because the introduction of pipeable operators in RxJS removed the need for Observables to have access to an `ofType()` method. Furthermore, `of()` is now a standalone Observable creation operator and does not need to be called on an Observable. Thus, we can create our `action$` stream as follows:
+As mentioned in the last lesson, `ActionsObservable` has been removed from redux-observable with the introduction of pipeable operators in RxJS. Furthermore, `of()` is now a standalone Observable creation operator and does not need to be called on an Observable. Thus, we can create our `action$` stream as follows:
 
 `const action$ = of(searchBeers("shane"))`
 
-See https://redux-observable.js.org/CHANGELOG.html#200-alpha0-2019-11-14 and https://rxjs.dev/api/index/function/of for more information.
-
 </Timestamp>
 
-<Timestamp start="2:01" end="2:25">
+<Timestamp start="2:01" end="2:15">
 
 Only received one `console.log` at this step: `{ type: 'SEARCHED_BEERS_LOADING', payload: true }`
 
 </Timestamp>
 
-<Timestamp start="3:35" end="4:40">
+<Timestamp start="3:55" end="4:25">
 
-Again, because `of()` is now a standalone Observable creation operator, we do not need to call it on an Observable. Our test should look like:
+Again, because `of()` is now a standalone Observable creation operator, we do not need to call it on an Observable. Our test should look as follows (some unchanged code/imports omitted):
 
 ```
 import { of } from "rxjs";
-import { searchBeersEpic } from ".";
-import { searchBeers } from "../actions";
+...
 it("should perform a search", function () {
   const action$ = of(searchBeers("shane"));
   const deps = {
@@ -91,18 +43,23 @@ it("should perform a search", function () {
 
 </Timestamp>
 
-<Timestamp start="5:12" end="6:07">
+<Timestamp start="5:12" end="5:22">
 
-We'll want to pipe `toArray()` into `output$`. Also, as mentioned in the prior lesson, I found that these tests would pass regardless of the assertions made. Passing in a `done` argument for the test and calling it at the end of the assertions fixed this issue (see https://stackoverflow.com/a/51640742). Now, the test passes almost immediately if the assertions hold and times out if the assertions are defied. Our working test should look like:
+We'll want to pipe `toArray()` into `output$`.
+
+```
+output$.pipe(toArray()).subscribe(...)
+```
+
+</Timestamp>
+
+<Timestamp start="5:30" end="6:15">
+
+As mentioned in the prior lesson, I found that these tests would pass regardless of the assertions made. Passing in a `done` argument for the test and calling it at the end of the assertions fixed this issue (see https://stackoverflow.com/a/51640742). Now, the test passes almost immediately if the assertions hold and times out if the assertions are defied. Our working test should look as follows (some unchanged code/imports omitted):
 
 ```
 import { of, toArray } from "rxjs";
-import { searchBeersEpic } from ".";
-import {
-  RECEIVED_BEERS,
-  searchBeers,
-  SEARCHED_BEERS_LOADING,
-} from "../actions";
+...
 it("should perform a search", function (done) {
   const action$ = of(searchBeers("shane"));
   const deps = {
@@ -112,19 +69,17 @@ it("should perform a search", function (done) {
   };
   const output$ = searchBeersEpic(action$, null, deps);
   output$.pipe(toArray()).subscribe((actions) => {
-    expect(actions.length).toBe(2);
-    expect(actions[0].type).toBe(SEARCHED_BEERS_LOADING);
-    expect(actions[1].type).toBe(RECEIVED_BEERS);
-    done();
+    // assertions go here
+    done(); // include this so that tests fail when they should
   });
 });
 ```
 
 </Timestamp>
 
-<Timestamp start="6:26" end="7:30">
+<Timestamp start="6:55" end="7:30">
 
-Middleware setup for redux-observable has changed a little bit in newer versions. Here is how it looks to include dependencies in our middleware on newer versions of redux-observable.
+Middleware setup for redux-observable has changed a little bit in newer versions. Also, `ajax` is now a standalone observable creation operator. So, we should now include dependencies in our middleware as follows:
 
 ```
 import { ajax } from "rxjs/ajax";
@@ -142,10 +97,16 @@ const store = createStore(
 epicMiddleware.run(rootEpic);
 ```
 
-See https://redux-observable.js.org/docs/basics/SettingUpTheMiddleware.html and https://rxjs.dev/api/ajax/ajax for more information.
-
 </Timestamp>
 
 We can mock what comes back from the network via an API call in our tests. This is a great technique if example data is accessible.
 
 We can include dependencies when we create our Epic middleware. Every Epic that is registered to the `rootEpic` running on the middleware will have access to those dependencies as a third argument.
+
+The following resources provide information about updates/deprecations to RxJS that are relevant to this lesson:
+
+-   https://redux-observable.js.org/CHANGELOG.html#200-alpha0-2019-11-14
+-   https://rxjs.dev/api/index/function/of
+-   https://stackoverflow.com/a/51640742
+-   https://redux-observable.js.org/docs/basics/SettingUpTheMiddleware.html
+-   https://rxjs.dev/api/ajax/ajax

--- a/up-and-running-with-redux-observable/notes/13-redux-use-tests-to-verify-updates-to-the-redux-store.md
+++ b/up-and-running-with-redux-observable/notes/13-redux-use-tests-to-verify-updates-to-the-redux-store.md
@@ -2,16 +2,11 @@
 
 <Timestamp start="0:00" end="0:30">
     
-With new versions of RxJS, tests should look a little different. Also, assertions that should have been failing were passing. To fix this, I had to include and call the `done` argument in the test. (see https://stackoverflow.com/a/51640742). The working test is given below:
+With new versions of RxJS, tests should look a little different. Also, assertions that should have been failing were passing. To fix this, I had to include and call the `done` argument in the test. (see https://stackoverflow.com/a/51640742). The working test is given below (some unchanged code/imports omitted):
 
 ```
 import { of, toArray } from "rxjs";
-import { searchBeersEpic } from ".";
-import {
-  RECEIVED_BEERS,
-  searchBeers,
-  SEARCHED_BEERS_LOADING,
-} from "../actions";
+...
 it("should perform a search", function (done) {
   const action$ = of(searchBeers("shane"));
   const deps = {
@@ -21,26 +16,21 @@ it("should perform a search", function (done) {
   };
   const output$ = searchBeersEpic(action$, null, deps);
   output$.pipe(toArray()).subscribe((actions) => {
-    expect(actions.length).toBe(2);
-    expect(actions[0].type).toBe(SEARCHED_BEERS_LOADING);
-    expect(actions[1].type).toBe(RECEIVED_BEERS);
-    done();
+    // assertions
+    done(); // include so that tests fail when they should
   });
 });
 ```
 
 </Timestamp>
 
-<Timestamp start="0:31" end="1:20">
+<Timestamp start="0:31" end="1:05">
 
-Middleware setup has changed some in newer versions of redux-observable. We need to create the Epic middleware, create the store and apply that middleware, then run the middleware with the `rootEpic`. So, our `configureStore()` function is going to look slightly different than what is presented in the lesson:
+Middleware setup has changed some in newer versions of redux-observable. We need to create the Epic middleware, create the store and apply that middleware, then run the middleware with the `rootEpic`. So, our `configureStore()` function is going to look slightly different than what is presented in the lesson (some unchanged imports omitted):
 
 ```
-import reducer from "./reducers";
 import { ajax } from "rxjs/ajax";
-import { applyMiddleware, compose, createStore } from "redux";
-import { createEpicMiddleware } from "redux-observable";
-import { rootEpic } from "./epics";
+...
 export function configureStore() {
   const epicMiddleware = createEpicMiddleware({
     dependencies: {
@@ -58,13 +48,11 @@ export function configureStore() {
 }
 ```
 
-See https://redux-observable.js.org/docs/basics/SettingUpTheMiddleware.html for more information.
-
 </Timestamp>
 
-<Timestamp start="4:28" end="4:40">
+<Timestamp start="4:28" end="4:45">
 
-Make sure to remove the `done` argument here. Since we are asserting on the Redux store and are not using Observables, we do not need to tell Jest when to finish the test.
+Make sure to remove the `done` argument here. Since we are asserting on the Redux store and not using Observables, we do not need to tell Jest when to finish the test.
 
 </Timestamp>
 
@@ -73,3 +61,8 @@ We can make assertions on the final state of our Redux store by extracting the s
 We ran into errors testing an Epic that used the `debounceTime()` operator. This is because, when we test synchronous Redux functionality, we expect everything to be completed by the time we make an assertion. Thus, the delay from `debounceTime()` causes our test to fail.
 
 We can use RxJS schedulers to solve the problem with `debounceTime()` in our tests. We can create a `new VirtualTimeScheduler()` and `flush()` it before our assertions are made. This executes any queued actions that it has built up as fast as possible.
+
+The following resources provide information about updates/deprecations to RxJS that are relevant to this lesson:
+
+-   https://stackoverflow.com/a/51640742
+-   https://redux-observable.js.org/docs/basics/SettingUpTheMiddleware.html


### PR DESCRIPTION
Previous timestamp notes were too long so I moved some things around and shortened code blocks. Lots of small syntax changes in newer versions of RxJS, so including those code blocks seems important for evergreen notes.

Also, I shortened the duration of many of the Timestamp elements.

![giphy-downsized-large](https://user-images.githubusercontent.com/45955761/127237396-804afe0c-0118-4176-9a16-07409de6161d.gif)
