### PR TITLE
updated script to print out template for notes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,12 @@ async function createLessonDocs (slug, items) {
 
   forEach(items, (item, i) => {
     const file = `${dir}/${addZero(i + 1)}_${item.slug}.md`;
-    const summary = `# ${item.title}\n\n[Video link](https://www.egghead.io${item.path})\n\n${item.transcript}\n`;
+    const notesTemplate = `<TimeStamp start="00:00" end="00:00">
+
+
+
+</TimeStamp>`
+    const summary = `# ${item.title}\n\n[Video link](https://www.egghead.io${item.path})\n\n${notesTemplate}\n`;
 
     writeFileToDir(file, summary)
   })


### PR DESCRIPTION
I updated the script to print out a template for the notes instead of the transcripts. 

```
<TimeStamp start="00:00" end="00:00">



</TimeStamp>
```

Example:
![Screen Shot 2021-11-02 at 1 26 28 PM](https://user-images.githubusercontent.com/26470581/139946936-020c9c00-847e-4965-8812-86ac6e414d09.png)

![](https://media0.giphy.com/media/SVrhnno6uiooNbza3p/giphy.gif?cid=5a38a5a23pw2vmrzhlwntsr6zud5tkjp3sbejrhqsrj9ymdn&rid=giphy.gif&ct=g)